### PR TITLE
Move from ChatML format to user/assistant format

### DIFF
--- a/_sft.ipynb
+++ b/_sft.ipynb
@@ -22,7 +22,7 @@
     "from transformers import GPT2Tokenizer\n",
     "\n",
     "from src import oasst, text_util\n",
-    "from src.model import GPT2, LoRAConfig\n",
+    "from src.model import GPT2\n",
     "from src.trainer import Trainer, TrainerConfig\n",
     "\n",
     "logging.basicConfig(level=logging.INFO)\n",
@@ -32,55 +32,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "af2d0b56",
    "metadata": {},
    "outputs": [],
    "source": [
-    "N_SAMPLES_TRAIN = 1_000\n",
-    "\n",
-    "lora_config = LoRAConfig(r=8, alpha=32)\n",
+    "N_SAMPLES_TRAIN = 2000\n",
     "\n",
     "trainer_config = TrainerConfig(\n",
     "    batch_size=8,\n",
     "    gradient_acc_steps=1,\n",
-    "    validation_samples=100,\n",
-    "    validation_interval=100,\n",
-    "    sample_prompts=[\n",
-    "        \"Hello, how are you?\",\n",
-    "        \"What's the best city for sun bathing?\",\n",
-    "        \"What does an architect do?\"\n",
-    "    ],\n",
     "    log_interval=8,\n",
     "    compile=False,\n",
-    "    base_learning_rate=3e-4,\n",
+    "    base_learning_rate=1e-4,\n",
     "    min_learning_rate=1e-6,\n",
-    "    lr_step_size=50_000_000,\n",
-    "    lr_gamma=0.33,\n",
-    "    weight_decay=1e-5,\n",
+    "    lr_step_size=100,\n",
+    "    lr_gamma=0.75,\n",
+    "    weight_decay=0.01,\n",
     "    betas=(0.9, 0.95),\n",
-    "    grad_clip=None,\n",
+    "    grad_clip=1.0,\n",
     "    num_workers=0,\n",
     "    prefetch_factor=None,\n",
-    "    pin_memory=False\n",
+    "    pin_memory=False,\n",
+    "    validation_samples=100,\n",
+    "    validation_interval=200,\n",
+    "    generate_sample_prompts=[\n",
+    "        \"How do I bake a cake?\",\n",
+    "        \"What are the best attractions in Rome, Italy?\",\n",
+    "        \"What does an architect do?\"\n",
+    "    ],\n",
+    "    generate_max_tokens=200,\n",
+    "    generate_temperature=1.0,\n",
+    "    generate_top_k=50,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "3a360db0",
    "metadata": {},
    "outputs": [],
    "source": [
     "tokenizer = GPT2Tokenizer.from_pretrained(\"gpt2\")\n",
-    "text_util.add_pad_token_to_tokenizer(tokenizer)\n",
-    "text_util.add_chatml_tokens_to_tokenizer(tokenizer)"
+    "text_util.add_pad_token_to_tokenizer(tokenizer)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3fb297a4",
    "metadata": {},
    "outputs": [
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "4fbdf76e",
    "metadata": {},
    "outputs": [
@@ -108,18 +108,19 @@
      "output_type": "stream",
      "text": [
       "INFO:src.model:Initializing a pre-trained gpt2 model...\n",
+      "INFO:src.model:Overriding dropout to 0.1\n",
       "INFO:src.model:Initialized GPT with 124.44 M parameters (of which 38.60 M in embeddings)\n",
       "INFO:src.model:Loading pre-trained weights from HuggingFace...\n"
      ]
     }
    ],
    "source": [
-    "model = GPT2.from_pretrained(\"gpt2\")"
+    "model = GPT2.from_pretrained(\"gpt2\", override_args={\"dropout\": 0.1})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "da4b3b6f",
    "metadata": {},
    "outputs": [
@@ -127,27 +128,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:src.model:Initialized GPT with 124.44 M parameters (of which 38.60 M in embeddings)\n",
-      "INFO:src.model:Extended token embeddings: 50257 -> 50260\n",
-      "INFO:src.model:Set padding embedding at index 50257 to zero\n",
-      "INFO:src.model:Initialized LoRA layers for modules: ['c_attn', 'c_proj', 'c_fc']\n",
-      "INFO:src.model:Registered selective gradient hook for 2 new tokens\n",
-      "INFO:src.model:Applied selective parameter freezing for LoRA and new token embeddings\n",
-      "INFO:src.model:LoRA initialized: num. of parameters requiring gradient computation: 124.44 M -> 39.78 M\n"
+      "INFO:src.model:Initialized GPT with 124.44 M parameters (of which 38.60 M in embeddings)\n"
      ]
     }
    ],
    "source": [
     "fine_tuneable = model.to_fine_tuneable()\n",
-    "init_from_index = tokenizer.encode(\"\\n\")[0]  # init new embs with \\n emb\n",
-    "fine_tuneable.extend_vocabulary(len(tokenizer), init_from_index)\n",
-    "fine_tuneable.set_padding_token(tokenizer.pad_token_id)\n",
-    "fine_tuneable.apply_lora(lora_config)"
+    "fine_tuneable.add_padding_token()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0610b6b4",
    "metadata": {},
    "outputs": [],
@@ -158,16 +150,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "8aaf3caa",
-   "metadata": {},
-   "source": [
-    "# Debug"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "49f04425",
    "metadata": {},
    "outputs": [
@@ -175,109 +159,93 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:src.trainer:Staring model training for 1000 samples...\n"
+      "INFO:src.trainer:Staring model training for 2000 samples...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🔄 iter:      0 │ 📊 samples:        8 │ 📉 loss: 103.7915 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      1 │ 📊 samples:       16 │ 📉 loss: 99.3314 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      2 │ 📊 samples:       24 │ 📉 loss: 96.7058 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      3 │ 📊 samples:       32 │ 📉 loss: 94.4074 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:      4 │ 📊 samples:       40 │ 📉 loss: 91.7139 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:      5 │ 📊 samples:       48 │ 📉 loss: 89.5895 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      6 │ 📊 samples:       56 │ 📉 loss: 86.4960 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      7 │ 📊 samples:       64 │ 📉 loss: 82.8014 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      8 │ 📊 samples:       72 │ 📉 loss: 75.3876 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:      9 │ 📊 samples:       80 │ 📉 loss: 66.9635 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     10 │ 📊 samples:       88 │ 📉 loss: 57.4729 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     11 │ 📊 samples:       96 │ 📉 loss: 47.7847 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     12 │ 📊 samples:      104 │ 📉 loss: 38.4849 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
+      "🔄 iter:      0 │ 📊 samples:        8 │ 📉 loss: 94.1180 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      1 │ 📊 samples:       16 │ 📉 loss: 67.4277 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      2 │ 📊 samples:       24 │ 📉 loss: 49.0198 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      3 │ 📊 samples:       32 │ 📉 loss: 38.2399 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      4 │ 📊 samples:       40 │ 📉 loss: 31.7503 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      5 │ 📊 samples:       48 │ 📉 loss: 27.3478 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      6 │ 📊 samples:       56 │ 📉 loss: 24.0879 │ 📈 lr:  1.00e-04 │ ⚡    1 samples/s\n",
+      "🔄 iter:      7 │ 📊 samples:       64 │ 📉 loss: 21.5943 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:      8 │ 📊 samples:       72 │ 📉 loss: 10.3398 │ 📈 lr:  1.00e-04 │ ⚡    1 samples/s\n",
+      "🔄 iter:      9 │ 📊 samples:       80 │ 📉 loss:  5.6349 │ 📈 lr:  1.00e-04 │ ⚡    1 samples/s\n",
+      "🔄 iter:     10 │ 📊 samples:       88 │ 📉 loss:  4.5529 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:     11 │ 📊 samples:       96 │ 📉 loss:  4.2332 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:     12 │ 📊 samples:      104 │ 📉 loss:  3.9641 │ 📈 lr:  1.00e-04 │ ⚡    0 samples/s\n",
+      "🔄 iter:     13 │ 📊 samples:      112 │ 📉 loss:  3.6780 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     14 │ 📊 samples:      120 │ 📉 loss:  3.4647 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     15 │ 📊 samples:      128 │ 📉 loss:  3.3509 │ 📈 lr:  7.50e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     16 │ 📊 samples:      136 │ 📉 loss:  3.2002 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     17 │ 📊 samples:      144 │ 📉 loss:  3.1241 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     18 │ 📊 samples:      152 │ 📉 loss:  3.0167 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     19 │ 📊 samples:      160 │ 📉 loss:  2.9931 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     20 │ 📊 samples:      168 │ 📉 loss:  2.9250 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     21 │ 📊 samples:      176 │ 📉 loss:  2.8772 │ 📈 lr:  7.50e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     22 │ 📊 samples:      184 │ 📉 loss:  2.9053 │ 📈 lr:  7.50e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     23 │ 📊 samples:      192 │ 📉 loss:  2.8672 │ 📈 lr:  7.50e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     24 │ 📊 samples:      200 │ 📉 loss:  2.8635 │ 📈 lr:  7.50e-05 │ ⚡    1 samples/s\n",
       "\n",
       "================================================================================\n",
       "VALIDATION RESULTS\n",
       "================================================================================\n",
-      "📊 METRICS (samples seen: 104)\n",
+      "📊 METRICS (samples seen: 200)\n",
       "----------------------------------------\n",
-      "  Loss:       7.5021\n",
-      "  Accuracy:   33.8%\n",
-      "  Perplexity: 5050.82\n",
+      "  Loss:       2.8909\n",
+      "  Accuracy:   46.2%\n",
+      "  Perplexity: 21.37\n",
       "\n",
       "🤖 SAMPLE COMPLETIONS\n",
       "----------------------------------------\n",
       "\n",
       "[Sample 1]\n",
-      "Prompt: Hello, how are you?\n",
-      "Response: userHello\n",
+      "Prompt: How do I bake a cake?\n",
+      "Response: In this scenario you ask your cake bakeries to bake a cake that is ready to go into the oven and then bake it.You can bake the cake up with butter, flour and sugar. You can bake it in a small pan with butter, buttermilk and baking powder. If you use a baking powder, it will only get better with time. You can give it a quick stir, buttermilk and baking powder are important\n",
       "------------------------------\n",
       "\n",
       "[Sample 2]\n",
-      "Prompt: What's the best city for culinarists?\n",
-      "Response: newyorkers\n",
+      "Prompt: What are the best attractions in Rome, Italy?\n",
+      "Response: To help you find out what is best in Rome, your first thing to do is to visit your local tourist site to check out the attractions. They are usually located on the beautiful side of town\n",
+      "you can enjoy a great Italian cuisine and drinks\n",
+      "------------------------------\n",
       "\n",
-      "New York City<|endoftext|>A year ago, when I was still an undergraduate.\n",
+      "[Sample 3]\n",
+      "Prompt: What does an architect do?\n",
+      "Response: I prefer to do architects only in terms of the basics of Architects. As I say, your skills have an important impact in building efficient buildings. As architects you should get skilled, but not necessarily experienced, in the construction.  You should find success in building efficient buildings like the ones in the above videos, without needing an expert architect and without a budget!STANDARD\n",
       "\n",
       "================================================================================\n",
       "\n",
-      "🔄 iter:     13 │ 📊 samples:      112 │ 📉 loss: 29.4755 │ 📈 lr:  3.00e-04 │ ⚡    0 samples/s\n",
-      "🔄 iter:     14 │ 📊 samples:      120 │ 📉 loss: 21.7691 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     15 │ 📊 samples:      128 │ 📉 loss: 15.2850 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     16 │ 📊 samples:      136 │ 📉 loss: 10.4033 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:     17 │ 📊 samples:      144 │ 📉 loss:  7.7173 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     18 │ 📊 samples:      152 │ 📉 loss:  6.5140 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     19 │ 📊 samples:      160 │ 📉 loss:  6.0315 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     20 │ 📊 samples:      168 │ 📉 loss:  5.9402 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     21 │ 📊 samples:      176 │ 📉 loss:  5.9288 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     22 │ 📊 samples:      184 │ 📉 loss:  5.9551 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     23 │ 📊 samples:      192 │ 📉 loss:  6.1888 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:     24 │ 📊 samples:      200 │ 📉 loss:  6.3280 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:     25 │ 📊 samples:      208 │ 📉 loss:  6.4325 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     26 │ 📊 samples:      216 │ 📉 loss:  6.4774 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     27 │ 📊 samples:      224 │ 📉 loss:  6.4968 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     28 │ 📊 samples:      232 │ 📉 loss:  6.5381 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     29 │ 📊 samples:      240 │ 📉 loss:  6.5028 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     30 │ 📊 samples:      248 │ 📉 loss:  6.3513 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     31 │ 📊 samples:      256 │ 📉 loss:  6.2143 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     32 │ 📊 samples:      264 │ 📉 loss:  6.1261 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     33 │ 📊 samples:      272 │ 📉 loss:  5.8650 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     34 │ 📊 samples:      280 │ 📉 loss:  5.7477 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     35 │ 📊 samples:      288 │ 📉 loss:  5.6364 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:     36 │ 📊 samples:      296 │ 📉 loss:  5.4848 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     37 │ 📊 samples:      304 │ 📉 loss:  5.3129 │ 📈 lr:  3.00e-04 │ ⚡    2 samples/s\n",
-      "🔄 iter:     38 │ 📊 samples:      312 │ 📉 loss:  5.2516 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     39 │ 📊 samples:      320 │ 📉 loss:  5.0865 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     40 │ 📊 samples:      328 │ 📉 loss:  4.9380 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     41 │ 📊 samples:      336 │ 📉 loss:  4.9083 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     42 │ 📊 samples:      344 │ 📉 loss:  4.7670 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     43 │ 📊 samples:      352 │ 📉 loss:  4.5826 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     44 │ 📊 samples:      360 │ 📉 loss:  4.4675 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     45 │ 📊 samples:      368 │ 📉 loss:  4.2536 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n",
-      "🔄 iter:     46 │ 📊 samples:      376 │ 📉 loss:  4.1448 │ 📈 lr:  3.00e-04 │ ⚡    1 samples/s\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[8]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mtrainer\u001b[49m\u001b[43m.\u001b[49m\u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43mN_SAMPLES_TRAIN\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/src/trainer.py:303\u001b[39m, in \u001b[36mTrainer.train\u001b[39m\u001b[34m(self, n_samples)\u001b[39m\n\u001b[32m    300\u001b[39m t0 = time.time()\n\u001b[32m    302\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(n_iter):\n\u001b[32m--> \u001b[39m\u001b[32m303\u001b[39m     loss = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_take_optimisation_step\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    304\u001b[39m     recent_losses.append(loss)\n\u001b[32m    306\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m._crossed_interval(\u001b[38;5;28mself\u001b[39m.config.log_interval):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/src/trainer.py:275\u001b[39m, in \u001b[36mTrainer._take_optimisation_step\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    273\u001b[39m         _, loss = \u001b[38;5;28mself\u001b[39m.model(**batch)\n\u001b[32m    274\u001b[39m         loss = loss / \u001b[38;5;28mself\u001b[39m.config.gradient_acc_steps\n\u001b[32m--> \u001b[39m\u001b[32m275\u001b[39m         \u001b[43mloss\u001b[49m\u001b[43m.\u001b[49m\u001b[43mbackward\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    276\u001b[39m         total_loss += loss.item()\n\u001b[32m    278\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.config.grad_clip \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/.venv/lib/python3.11/site-packages/torch/_tensor.py:648\u001b[39m, in \u001b[36mTensor.backward\u001b[39m\u001b[34m(self, gradient, retain_graph, create_graph, inputs)\u001b[39m\n\u001b[32m    638\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m has_torch_function_unary(\u001b[38;5;28mself\u001b[39m):\n\u001b[32m    639\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m handle_torch_function(\n\u001b[32m    640\u001b[39m         Tensor.backward,\n\u001b[32m    641\u001b[39m         (\u001b[38;5;28mself\u001b[39m,),\n\u001b[32m   (...)\u001b[39m\u001b[32m    646\u001b[39m         inputs=inputs,\n\u001b[32m    647\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m648\u001b[39m \u001b[43mtorch\u001b[49m\u001b[43m.\u001b[49m\u001b[43mautograd\u001b[49m\u001b[43m.\u001b[49m\u001b[43mbackward\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    649\u001b[39m \u001b[43m    \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgradient\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mretain_graph\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreate_graph\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m=\u001b[49m\u001b[43minputs\u001b[49m\n\u001b[32m    650\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/.venv/lib/python3.11/site-packages/torch/autograd/__init__.py:353\u001b[39m, in \u001b[36mbackward\u001b[39m\u001b[34m(tensors, grad_tensors, retain_graph, create_graph, grad_variables, inputs)\u001b[39m\n\u001b[32m    348\u001b[39m     retain_graph = create_graph\n\u001b[32m    350\u001b[39m \u001b[38;5;66;03m# The reason we repeat the same comment below is that\u001b[39;00m\n\u001b[32m    351\u001b[39m \u001b[38;5;66;03m# some Python versions print out the first line of a multi-line function\u001b[39;00m\n\u001b[32m    352\u001b[39m \u001b[38;5;66;03m# calls in the traceback and some print out the last line\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m353\u001b[39m \u001b[43m_engine_run_backward\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    354\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtensors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    355\u001b[39m \u001b[43m    \u001b[49m\u001b[43mgrad_tensors_\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    356\u001b[39m \u001b[43m    \u001b[49m\u001b[43mretain_graph\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    357\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcreate_graph\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    358\u001b[39m \u001b[43m    \u001b[49m\u001b[43minputs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    359\u001b[39m \u001b[43m    \u001b[49m\u001b[43mallow_unreachable\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m    360\u001b[39m \u001b[43m    \u001b[49m\u001b[43maccumulate_grad\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m    361\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/.venv/lib/python3.11/site-packages/torch/autograd/graph.py:824\u001b[39m, in \u001b[36m_engine_run_backward\u001b[39m\u001b[34m(t_outputs, *args, **kwargs)\u001b[39m\n\u001b[32m    822\u001b[39m     unregister_hooks = _register_logging_hooks_on_whole_graph(t_outputs)\n\u001b[32m    823\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m824\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mVariable\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_execution_engine\u001b[49m\u001b[43m.\u001b[49m\u001b[43mrun_backward\u001b[49m\u001b[43m(\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# Calls into the C++ engine to run the backward pass\u001b[39;49;00m\n\u001b[32m    825\u001b[39m \u001b[43m        \u001b[49m\u001b[43mt_outputs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\n\u001b[32m    826\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# Calls into the C++ engine to run the backward pass\u001b[39;00m\n\u001b[32m    827\u001b[39m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[32m    828\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m attach_logging_hooks:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/Omat/projects/GPT2-Fine-Tune/src/model.py:567\u001b[39m, in \u001b[36mFineTuneableGPT2._register_selective_embedding_hook.<locals>.selective_embedding_hook\u001b[39m\u001b[34m(grad)\u001b[39m\n\u001b[32m    562\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_register_selective_embedding_hook\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[32m    563\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m    564\u001b[39m \u001b[33;03m    Register a backward hook to selectively compute gradients only for new token\u001b[39;00m\n\u001b[32m    565\u001b[39m \u001b[33;03m    embeddings (excluding padding token)\u001b[39;00m\n\u001b[32m    566\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m567\u001b[39m     \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mselective_embedding_hook\u001b[39m(grad):\n\u001b[32m    568\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m grad \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    569\u001b[39m             \u001b[38;5;28;01mreturn\u001b[39;00m grad\n",
-      "\u001b[31mKeyboardInterrupt\u001b[39m: "
+      "🔄 iter:     25 │ 📊 samples:      208 │ 📉 loss:  2.9545 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     26 │ 📊 samples:      216 │ 📉 loss:  2.9508 │ 📈 lr:  5.63e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     27 │ 📊 samples:      224 │ 📉 loss:  2.9127 │ 📈 lr:  5.63e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     28 │ 📊 samples:      232 │ 📉 loss:  2.8665 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     29 │ 📊 samples:      240 │ 📉 loss:  2.8502 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     30 │ 📊 samples:      248 │ 📉 loss:  2.7831 │ 📈 lr:  5.63e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     31 │ 📊 samples:      256 │ 📉 loss:  2.7108 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     32 │ 📊 samples:      264 │ 📉 loss:  2.7060 │ 📈 lr:  5.63e-05 │ ⚡    1 samples/s\n",
+      "🔄 iter:     33 │ 📊 samples:      272 │ 📉 loss:  2.6601 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     34 │ 📊 samples:      280 │ 📉 loss:  2.7261 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n",
+      "🔄 iter:     35 │ 📊 samples:      288 │ 📉 loss:  2.7447 │ 📈 lr:  5.63e-05 │ ⚡    0 samples/s\n"
      ]
     }
    ],
    "source": [
     "trainer.train(N_SAMPLES_TRAIN)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9a4d593",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/model.py
+++ b/src/model.py
@@ -218,9 +218,9 @@ class GPT2(nn.Module):
         return logits, loss
 
     @staticmethod
-    def _should_stop(x, stop_tokens):
-        n = len(stop_tokens)
-        return x.view(-1)[-n:].cpu().tolist() == stop_tokens
+    def _should_stop(x, end_tokens):
+        n = len(end_tokens)
+        return x.view(-1)[-n:].cpu().tolist() == end_tokens
 
     @torch.no_grad()
     def generate(
@@ -229,7 +229,7 @@ class GPT2(nn.Module):
         max_tokens,
         temperature=1.0,
         top_k=None,
-        stop_tokens=None,  # list of token ids
+        end_tokens=None,
         prevent_tokens=None,
     ):
         if x.dim() != 2:
@@ -251,7 +251,7 @@ class GPT2(nn.Module):
             x_next = torch.multinomial(probs, num_samples=1)  # [B, 1]
             x = torch.cat((x, x_next), dim=1)  # [B, S + 1]
 
-            if stop_tokens is not None and self._should_stop(x, stop_tokens):
+            if end_tokens is not None and self._should_stop(x, end_tokens):
                 break
 
         return x

--- a/src/oasst.py
+++ b/src/oasst.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import datasets
 from datasets import Dataset
 
-from src.chatml import ChatMLPreprocessor
+from src.preprocess import ConversationPreprocessor
 
 
 def _parse_valid_conversations_from_tree(
@@ -119,7 +119,7 @@ def load_oasst_dataset(name, tokenizer, ignored_idx=-100, num_proc=4):
     for split in ["train", "validation"]:
         conversations = _parse_conversations(full_dataset[split])
         dataset = Dataset.from_list(conversations)
-        preprocessor = ChatMLPreprocessor(tokenizer, ignored_idx)
+        preprocessor = ConversationPreprocessor(tokenizer, ignored_idx)
         datasets.logging.disable_progress_bar()
         preprocessed_dataset = dataset.map(preprocessor, num_proc=num_proc)
         datasets_.append(preprocessed_dataset)

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -2,10 +2,8 @@ import re
 
 import torch
 
-from src import text_util
 
-
-class ChatMLPreprocessor:
+class ConversationPreprocessor:
     def __init__(self, tokenizer, ignored_idx=-100, max_length=None):
         self.tokenizer = tokenizer
         self.ignored_idx = ignored_idx
@@ -17,16 +15,25 @@ class ChatMLPreprocessor:
         if for_generation:
             return self.encode_conversation_for_generation_to_tokens(conversation)
         return self.encode_conversation_to_tokens(conversation)
-        
 
     def encode_conversation_to_tokens(self, conversation):
         """
-        Convert conversation to tokenized ChatML format for training.
+        Convert conversation to tokenized User/Assistant chat format for training.
+
+        Inputs are assumed to conform to format
+
+            {"messages": [{"role": "user|assistant", "content": "..."}]}
+        
+        The conversations are then converted to chat format
+
+            user: <content><|endoftext|>
+            assistant: <content><|endoftext|>
+
+        And the text is then tokenized.
 
         Args:
             conversation: {"messages": [{"role": "user|assistant", "content": "..."}]}
-            return_labels: Whether to return labels for loss computation
-            
+
         Returns:
             {"input_ids": [...], "labels": [...]}
         """
@@ -34,11 +41,10 @@ class ChatMLPreprocessor:
 
         input_ids = []
         labels = []
-        
+
         for msg in conversation["messages"]:
             role, content = msg["role"], msg["content"]
 
-            # <|im_start|>role\ncontent<|im_end|>\n
             msg_ids, msg_labels = self._encode_message(role, content)
             input_ids.extend(msg_ids)
             labels.extend(msg_labels)
@@ -53,11 +59,11 @@ class ChatMLPreprocessor:
 
     def encode_conversation_for_generation_to_tokens(self, conversation):
         """
-        Convert conversation to tokenized ChatML format for generation.
+        Convert conversation to tokenized chat format for generation.
 
         The conversation must end with an assistant message, which can have empty
         content ("", None).
-        The final assistant message will be left incomplete (no <|im_end|> token) 
+        The final assistant message will be left incomplete (no eos_token) 
         to prompt the model to continue generation.
 
         Args:
@@ -105,10 +111,8 @@ class ChatMLPreprocessor:
                 token_ids = token_ids[0]
             token_ids = token_ids.tolist()
 
-        chatml_text = text_util.decode_by_token(
-            self.tokenizer, token_ids, skip_special_tokens=False
-        )
-        conversation = self._parse_chatml_text(chatml_text)
+        chat_text = self.tokenizer.decode(token_ids, skip_special_tokens=False)
+        conversation = self._parse_chat_text(chat_text)
         self._validate_conversation(conversation)
         return conversation
 
@@ -117,22 +121,18 @@ class ChatMLPreprocessor:
         ids = []
         labels = []
 
-        # <|im_start|>
-        ids.append(self.tokenizer.im_start_token_id)
-        labels.append(self.ignored_idx)
-
-        # role
-        role_tokens = self.tokenizer.encode(role, add_special_tokens=False)
+        # role + space
+        role_ = role + ": "
+        role_tokens = self.tokenizer.encode(role_, add_special_tokens=False)
         ids.extend(role_tokens)
         labels.extend([self.ignored_idx] * len(role_tokens))
 
-        # \n
-        ids.append(self.tokenizer.encode("\n", add_special_tokens=False)[0])
-        labels.append(self.ignored_idx)
-
         # content
         content_tokens = self.tokenizer.encode(
-            content, add_special_tokens=False, truncation=True, max_length=self.max_length
+            content,
+            add_special_tokens=False,
+            truncation=True,
+            max_length=self.max_length
         )
         ids.extend(content_tokens)
 
@@ -141,12 +141,13 @@ class ChatMLPreprocessor:
         else:
             labels.extend([self.ignored_idx] * len(content_tokens))
 
-        # <|im_end|>
-        ids.append(self.tokenizer.im_end_token_id)
+        # end
+        end_tokens = self.tokenizer.encode("!END", add_special_tokens=False)
+        ids.extend(end_tokens)
         if role == "assistant":
-            labels.append(self.tokenizer.im_end_token_id)
+            labels.extend(end_tokens)
         else:
-            labels.append(self.ignored_idx)
+            labels.extend([self.ignored_idx] * len(end_tokens))
 
         # \n
         ids.append(self.tokenizer.encode("\n", add_special_tokens=False)[0])
@@ -156,7 +157,7 @@ class ChatMLPreprocessor:
 
     def _encode_message_for_generation(self, role, content):
         """
-        Encode a message for generation: No <|im_end|> token or trailing newline.
+        Encode a message for generation.
 
         This method is specifically for the final assistant message in generation,
         leaving it incomplete so the model continues from there.
@@ -166,42 +167,40 @@ class ChatMLPreprocessor:
 
         ids = []
 
-        # <|im_start|>
-        ids.append(self.tokenizer.im_start_token_id)
-
-        # role
-        role_tokens = self.tokenizer.encode(role, add_special_tokens=False)
+        # role + space
+        role_ = role + ": "
+        role_tokens = self.tokenizer.encode(role_, add_special_tokens=False)
         ids.extend(role_tokens)
-
-        # \n
-        ids.append(self.tokenizer.encode("\n", add_special_tokens=False)[0])
 
         # content (if any)
         if content:
             content_tokens = self.tokenizer.encode(
-                content, add_special_tokens=False, truncation=True, max_length=self.max_length
+                content,
+                add_special_tokens=False,
+                truncation=True,
+                max_length=self.max_length
             )
             ids.extend(content_tokens)
 
         return ids
 
-    def _parse_chatml_text(self, chatml_text):
+    def _parse_chat_text(self, chat_text):
         """
-        Parse ChatML formatted text back into conversation format.
-
-        Uses regex to robustly extract role and content from each message block.
+        Parse User/Assistant formatted text back into conversation format.
+        Uses regex to extract role and content from each message block.
         """
 
-        esc_start = re.escape(self.tokenizer.im_start_token)
-        esc_end = re.escape(self.tokenizer.im_end_token)
+        esc_end = re.escape("!END")
 
-        pattern = rf"{esc_start}\s*(\w+)\n(.*?){esc_end}"
-        matches = re.findall(pattern, chatml_text, flags=re.DOTALL)
-
+        # Pattern to match "role: content!END" blocks
+        pattern = rf"(user|assistant):\s*(.*?){esc_end}"
+        matches = re.findall(pattern, chat_text, flags=re.DOTALL)
+        
         messages = []
         for role, content in matches:
-            messages.append({"role": role, "content": content.strip()})
-
+            normalized_role = role.lower()
+            messages.append({"role": normalized_role, "content": content.strip()})
+        
         return {"messages": messages}
     
     def _validate_conversation(self, conversation):

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -3,13 +3,24 @@ import re
 import torch
 
 
+_TURN_SEPARATOR = "!END"
+
+
 class ConversationPreprocessor:
-    def __init__(self, tokenizer, ignored_idx=-100, max_length=None):
+    def __init__(
+        self,
+        tokenizer,
+        ignored_idx=-100,
+        max_length=None,
+        turn_separator=_TURN_SEPARATOR,
+    ):
         self.tokenizer = tokenizer
         self.ignored_idx = ignored_idx
         self.max_length = (
             tokenizer.model_max_length if max_length is None else max_length
         )
+        self.turn_separator = turn_separator
+        self.stop_tokens = self.tokenizer.encode(turn_separator)
 
     def __call__(self, conversation, for_generation=False):
         if for_generation:

--- a/src/text_util.py
+++ b/src/text_util.py
@@ -1,30 +1,8 @@
 PAD_TOKEN = "<|pad|>"
-IM_START_TOKEN = "<|im_start|>"
-IM_END_TOKEN = "<|im_end|>"
 
 
 def add_pad_token_to_tokenizer(tokenizer, pad_token=PAD_TOKEN):
     tokenizer.add_special_tokens({"pad_token": pad_token})
-
-
-def add_chatml_tokens_to_tokenizer(
-    tokenizer, im_start_token=IM_START_TOKEN, im_end_token=IM_END_TOKEN
-):
-    tokenizer.add_special_tokens(
-        {"additional_special_tokens": [im_start_token, im_end_token]}
-    )
-
-    tokenizer.im_start_token = im_start_token
-    tokenizer.im_end_token = im_end_token
-
-    tokenizer.im_start_token_id = tokenizer.convert_tokens_to_ids(im_start_token)
-    tokenizer.im_end_token_id = tokenizer.convert_tokens_to_ids(im_end_token)
-
-
-def decode_by_token(tokenizer, ids, **tokenizer_kwargs):
-    # avoid spaces around ChatML im tokens, can't get rid of them when applying calling
-    # tokenizer.decode(ids) directly
-    return "".join([tokenizer.decode(i, **tokenizer_kwargs) for i in ids])
 
 
 def make_user_conversation(user_prompt):
@@ -36,17 +14,17 @@ def make_user_conversation(user_prompt):
     }
 
 
-def get_last_assistant_message_content(conversation):
-    # find assistant's last message and return its content
-    for msg in reversed(conversation["messages"]):
-        if msg["role"] == "assistant":
-            return msg["content"]
-    return
-
-
 def add_assistant_message(conversation, assistant_content):
     # add an assistant message to an existing conversation
     messages = conversation["messages"] + [
         {"role": "assistant", "content": assistant_content}
     ]
     return {"messages":  messages}
+
+
+def get_last_assistant_message_content(conversation):
+    # find assistant's last message and return its content
+    for msg in reversed(conversation["messages"]):
+        if msg["role"] == "assistant":
+            return msg["content"]
+    return

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -166,7 +166,7 @@ class Trainer:
         self, config, model, tokenizer, train_dataset, validation_dataset, device
     ):
         self.config = config
-        self.model = model
+        self.model = model.to(device)
         self.tokenizer = tokenizer
         self.device = device
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -210,7 +210,6 @@ class Trainer:
             self.ctx,
             device,
             prevent_tokens=[tokenizer.pad_token_id],
-            stop_tokens=tokenizer.encode("!END"),
         )
 
     def _get_next_batch(self, mode="train"):

--- a/src/validation.py
+++ b/src/validation.py
@@ -22,7 +22,6 @@ class BaseValidator(ABC):
         ctx,
         device,
         prevent_tokens=None,
-        stop_tokens=None,
     ):
         self.model = model
         self.tokenizer = tokenizer
@@ -30,7 +29,6 @@ class BaseValidator(ABC):
         self.ctx = ctx
         self.device = device
         self.prevent_tokens = prevent_tokens
-        self.stop_tokens = stop_tokens
 
         self.preprocessor = ConversationPreprocessor(
             tokenizer, model.config.ignored_idx
@@ -57,18 +55,9 @@ class BaseValidator(ABC):
 
 class SFTValidator(BaseValidator):
     def __init__(
-        self,
-        model,
-        tokenizer,
-        trainer_config,
-        ctx,
-        device,
-        prevent_tokens=None,
-        stop_tokens=None,
+        self, model, tokenizer, trainer_config, ctx, device, prevent_tokens=None
     ):
-        super().__init__(
-            model, tokenizer, trainer_config, ctx, device, prevent_tokens, stop_tokens
-        )
+        super().__init__(model, tokenizer, trainer_config, ctx, device, prevent_tokens)
 
     def compute_batch_metrics(self, batch):
         with self.ctx, torch.no_grad():
@@ -104,7 +93,7 @@ class SFTValidator(BaseValidator):
                     max_tokens=100,  # TODO config
                     temperature=1.0,  # TODO config
                     top_k=50,  # TODO config
-                    stop_tokens=self.stop_tokens,
+                    stop_tokens=self.preprocessor.stop_tokens,
                     prevent_tokens=self.prevent_tokens,
                 )
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -4,7 +4,7 @@ import torch
 import numpy as np
 
 from src import text_util
-from src.chatml import ChatMLPreprocessor
+from src.preprocess import ConversationPreprocessor
 
 
 def _make_conversation_for_sample_generation(user_prompt):
@@ -22,7 +22,7 @@ class BaseValidator(ABC):
         ctx,
         device,
         prevent_tokens=None,
-        stop_token=None,
+        stop_tokens=None,
     ):
         self.model = model
         self.tokenizer = tokenizer
@@ -30,9 +30,11 @@ class BaseValidator(ABC):
         self.ctx = ctx
         self.device = device
         self.prevent_tokens = prevent_tokens
-        self.stop_token = stop_token
+        self.stop_tokens = stop_tokens
 
-        self.preprocessor = ChatMLPreprocessor(tokenizer, model.config.ignored_idx)
+        self.preprocessor = ConversationPreprocessor(
+            tokenizer, model.config.ignored_idx
+        )
 
     @abstractmethod
     def compute_batch_metrics(self, batch):
@@ -62,10 +64,10 @@ class SFTValidator(BaseValidator):
         ctx,
         device,
         prevent_tokens=None,
-        stop_token=None,
+        stop_tokens=None,
     ):
         super().__init__(
-            model, tokenizer, trainer_config, ctx, device, prevent_tokens, stop_token
+            model, tokenizer, trainer_config, ctx, device, prevent_tokens, stop_tokens
         )
 
     def compute_batch_metrics(self, batch):
@@ -102,7 +104,7 @@ class SFTValidator(BaseValidator):
                     max_tokens=100,  # TODO config
                     temperature=1.0,  # TODO config
                     top_k=50,  # TODO config
-                    stop_token=self.stop_token,
+                    stop_tokens=self.stop_tokens,
                     prevent_tokens=self.prevent_tokens,
                 )
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -81,7 +81,7 @@ class SFTValidator(BaseValidator):
     def generate_samples(self):
         samples = []
 
-        for prompt in self.trainer_config.sample_prompts:
+        for prompt in self.trainer_config.generate_sample_prompts:
 
             conversation = _make_conversation_for_sample_generation(prompt)
             processed = self.preprocessor(conversation, for_generation=True)
@@ -90,10 +90,10 @@ class SFTValidator(BaseValidator):
             with self.ctx, torch.no_grad():
                 generated = self.model.generate(
                     x,
-                    max_tokens=100,  # TODO config
-                    temperature=1.0,  # TODO config
-                    top_k=50,  # TODO config
-                    stop_tokens=self.preprocessor.stop_tokens,
+                    max_tokens=self.trainer_config.generate_max_tokens,
+                    temperature=self.trainer_config.generate_temperature,
+                    top_k=self.trainer_config.generate_top_k,
+                    end_tokens=self.preprocessor.end_tokens,
                     prevent_tokens=self.prevent_tokens,
                 )
 


### PR DESCRIPTION
Move from ChatML format to user/assistant format with `!END` turn separator. This is done to avoid having to extend token embedding table with im end and start tokens. Model had significant difficulties learning the semantic meaning of these tokens, while simultaneously having to familiarize itself with the new chat format.